### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,9 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/board
-    username: postgres
-    password: 1584
+    url: ${LOCAL_DB-URL}
+    username: ${LOCAL_DB-USERNAME}
+    password: ${LOCAL_DB-PASSWORD}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
이 pr은 `appliaction.yaml` 에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경스도록 한다.
그러나.. 사실 이미 늦었다. 이전 과거 기록(커밋 노드) 을 조회하면 여전히 노출된 값을 볼 수 있기 때문.
근본적인 해결을 하려면 이 저장소를 통째로 지우고 새로 올리는 수 밖에 없을 것 같다.
일단 공부를 하는 의미는 있으므로 이 pr을 적용한다.

This closes #67 